### PR TITLE
Various fixes for debbuild

### DIFF
--- a/debbuild
+++ b/debbuild
@@ -575,8 +575,8 @@ LINE: while (<SPECFILE>) {
 		not /^%(?:attr|bcond_with|bcond_without|build|changelog|check|
 		clean|config|configure|copyrightdata|defattr|define|description|
 		dir|doc|docdir|else|endif|files|ghost|if|ifarch|ifnarch|
-		ifnos|ifos|install|make_install|makeinstall|package|patch\d*|
-		post|postun|pre|prep|preun|readme|setup\d*|triggerin|
+		ifnos|ifos|install|make_build|make_install|makeinstall|package|
+		patch\d*|post|postun|pre|prep|preun|readme|setup\d*|triggerin|
 		triggerpostun|triggerun|verify|verifyscript)\b/x) {
 	my ($badtag) = /^%([a-z]+)/i;
 	die "Unknown tag \%$badtag at line $. of $specfile\n";
@@ -1731,7 +1731,7 @@ sub expandmacros {
       "<<<$_>>>. Aborting!\n" if $specglobals{NEST}++ > 8;
 
   # Replace global macros
-  s/%(configure|make_install|makeinstall|optflags)/%{$1}/g;
+  s/%(configure|make_build|make_install|makeinstall|optflags)/%{$1}/g;
   s|%{optflags}|$optflags{$pkgdata{main}{arch}}|g;
 
   # Package data

--- a/debbuild
+++ b/debbuild
@@ -574,7 +574,7 @@ LINE: while (<SPECFILE>) {
     if (/^%[a-z]/ &&
 		not /^%(?:attr|bcond_with|bcond_without|build|changelog|check|
 		clean|config|configure|copyrightdata|defattr|define|description|
-		dir|doc|docdir|else|endif|files|ghost|if|ifarch|ifnarch|
+		dir|doc|docdir|else|endif|files|ghost|global|if|ifarch|ifnarch|
 		ifnos|ifos|install|make_build|make_install|makeinstall|package|
 		patch\d*|post|postun|pre|prep|preun|readme|setup\d*|triggerin|
 		triggerpostun|triggerun|verify|verifyscript)\b/x) {

--- a/debbuild
+++ b/debbuild
@@ -191,22 +191,20 @@ my %ubnt_vermap = ("6.5ubuntu6" => "12.04",
     }
   } # got dpkg-query?
 
+  # rpmbuild expects either integers or strings, and some distros (*cough*Ubuntu*cough*)
+  # have versions that get interpreted as strings, which creates comparison problems.
+  # This will make sure it's an integer to remain compatible.
+  my $specbasever;
+  $specbasever = $basever;
+  $specbasever =~ s?[\.]??;
+
   # Set some legacy globals.
   $specglobals{debdist} = $distmap{$basever};
-  $specglobals{debver} = $basever;   # this may have trouble with Ubuntu versions?
+  $specglobals{debver} = $specbasever;   # this may have trouble with Ubuntu versions?
 
   # Set the standard generic OS-class globals;
   $baseos = lc $baseos;
-  $specglobals{debian} = $basever if $baseos eq 'debian';
-
-  # rpmbuild expects either integers or strings, and Ubuntu version becomes a string
-  # This will make sure it's an integer to remain compatible
-  if ($baseos eq 'ubuntu') {
-      my $baseveralt;
-      $baseveralt = $basever;
-      $baseveralt =~ s?[\.]??;
-      $specglobals{ubuntu} = $baseveralt;
-  }
+  $specglobals{$baseos} = $specbasever;
 
   # Default %{dist} to something marginally sane.  Note this should be overrideable by --define.
   # This has been chosen to most closely follow the usage in RHEL/CentOS and Fedora, ie "el5" or "fc20".

--- a/debbuild
+++ b/debbuild
@@ -197,8 +197,16 @@ my %ubnt_vermap = ("6.5ubuntu6" => "12.04",
 
   # Set the standard generic OS-class globals;
   $baseos = lc $baseos;
-  $specglobals{ubuntu} = $basever if $baseos eq 'ubuntu';
   $specglobals{debian} = $basever if $baseos eq 'debian';
+
+  # rpmbuild expects either integers or strings, and Ubuntu version becomes a string
+  # This will make sure it's an integer to remain compatible
+  if ($baseos eq 'ubuntu') {
+      my $baseveralt;
+      $baseveralt = $basever;
+      $baseveralt =~ s?[\.]??;
+      $specglobals{ubuntu} = $baseveralt;
+  }
 
   # Default %{dist} to something marginally sane.  Note this should be overrideable by --define.
   # This has been chosen to most closely follow the usage in RHEL/CentOS and Fedora, ie "el5" or "fc20".

--- a/debbuild.spec
+++ b/debbuild.spec
@@ -12,7 +12,7 @@ Release: ascherer.%{dist}
 
 Source: https://github.com/ascherer/debbuild/archive/%{name}-%{version}.tar.gz
 URL: https://github.com/ascherer/debbuild
-%if %{_vendor} = "debbuild"
+%if %{_vendor} == "debbuild"
 # Use Debian sections here
 Group: devel
 %else

--- a/glomacros
+++ b/glomacros
@@ -177,10 +177,10 @@ package or when debugging this package.\
 #	Macros that are specific to an individual platform. The values here
 #	will be used if the per-platform macro file does not exist..
 #
-%_arch			i386
-%_build_arch		i386
+%_arch			@HOST_ARCH@
+%_build_arch		@BUILD_ARCH@
 %_vendor		debbuild
-%_os			linux
+%_os			@HOST_OS@
 
 #==============================================================================
 # ---- Scriptlet template templates.
@@ -254,11 +254,11 @@ package or when debugging this package.\
 %_build_cpu		%{_host_cpu}
 %_build_vendor		%{_host_vendor}
 %_build_os		%{_host_os}
-%_host			i686-pc-linux-gnu
+%_host			@HOST_CPU@-pc-@HOST_SYSTEM@
 %_host_alias		%{nil}
-%_host_cpu		i686
+%_host_cpu		@HOST_CPU@
 %_host_vendor		pc
-%_host_os		linux
+%_host_os		@HOST_OS@
 %_target		%{_host}
 %_target_alias		%{_host_alias}
 %_target_cpu		%{_host_cpu}

--- a/glomacros
+++ b/glomacros
@@ -299,6 +299,10 @@ package or when debugging this package.\
 	--infodir=%{_infodir}
 
 #------------------------------------------------------------------------------
+# The "make" analogue, hiding the _smp_mflags magic from specs
+%make_build %{__make} %{?_smp_mflags}
+
+#------------------------------------------------------------------------------
 # The make install analogue of %configure for modern autotools:
 %make_install %{__make} install DESTDIR=%{?buildroot}
 


### PR DESCRIPTION
This pull request includes various fixes for debbuild to correct behavior with `%{ubuntu}`, `%global`, and environment setup.

Additionally, `%make_build` from RPM 4.12 (included in Debian 8.x / Ubuntu 15.04+) is now supported.