### PR TITLE
Fix default %_topdir to point to ~/debbuild

### DIFF
--- a/glomacros
+++ b/glomacros
@@ -153,7 +153,7 @@ package or when debugging this package.\
 %_tmppath		%{_var}/tmp
 
 #	Path to top of build area.
-%_topdir		%{getenv:HOME}/rpmbuild
+%_topdir		%{getenv:HOME}/debbuild
 
 #==============================================================================
 # ---- Optional rpmrc macros.


### PR DESCRIPTION
The `%_topdir` macro still pointed to ~/rpmbuild, which needed to be changed.