### PR TITLE
WIP: Fix OS detection to use either os-release(5) or 'lsb_release' only

### DIFF
--- a/debbuild
+++ b/debbuild
@@ -94,109 +94,32 @@ my %optflags = ( 'i386' => '-O2 -g -march=i386 -mcpu=i686',
 		'amd64'	=> '-O2 -g',
 		  'all'	=> '');
 
-# Hackery to try to bring some semblance of sanity to packages built for more
-# than one Debian version at the same time.  Whee.
-# /etc/debian-version and/or version of base-files package
-my %distmap = (
-# legacy Unbuntu
-	'3.1.9ubuntu'	=> 'dapper',
-	'6.06'		=> 'dapper',
-	'4ubuntu'	=> 'feisty',
-	'7.04'		=> 'feisty',
-        '4.0.1ubuntu'	=> 'hardy',
-	'8.04'		=> 'hardy',
-# Note we do NOT support identification of "subrelease" versions (ie semimajor updates
-# to a given release).  If your dependencies are really that tight, and you can't rely
-# on the versions of the actual dependencies, you're already in over your head, and
-# should probably only ship a tarballed installer.
-# only supporting LTS releases
-# base-files version doesn't map to the Ubuntu version the way Debian versions do, thus the doubled entries
-#	Ubuntu 12.04.5 LTS (Precise Pangolin)
-	'6.5ubuntu'	=> 'precise',
-	'12.04'		=> 'precise',
-#	Ubuntu 14.04.2 LTS (Trusty Tahr)
-	'7.2ubuntu'	=> 'trusty',
-	'14.04'		=> 'trusty',
-#	Ubuntu 16.04.0 LTS (Xenial Xerus)
-	'9.4ubuntu'	=> 'xenial',
-	'16.04'		=> 'xenial',
-# Debian releases
-	'3.0'	=> 'woody',
-	'3.1'	=> 'sarge',
-	'4'	=> 'etch',
-	'5'	=> 'lenny',
-	'6'	=> 'squeeze',
-	'7'	=> 'wheezy',
-	'8'	=> 'jessie',
-	'9'	=> 'stretch',
-	'99'	=> 'sid');
-
-# Enh.  There doesn't seem to be any better way to do this...  :(
 {
-# could theoretically also do something with this...  it's about as stable as "dpkg-query ..." below...  :(
-#  chomp( my $releasever = qx ( $specglobals{__cat} /etc/debian_version ) );
+# Setup for OS detection
   my $basever;
   my $baseos;
+  my $basecodename;
 
   # Funny thing how files like this have become useful...
-  # Check for /etc/os-release.  If that doesn't exist, try /etc/lsb-release.  If that doesn't exist,
-  # check for existence of dpkg-query, and either call it Debian Woody (if missing), or fall through
-  # to guessing based on the version of the base-files package.
+  # Check for /etc/os-release.  If that doesn't exist, try calling lsb_release.
+  # If neither exist, then die, as we don't really care anymore...
   if (open OSREL, '/etc/os-release') {
-    # Look for ID and VERSION_ID lines.
+    # Look for ID, VERSION_ID, and VERSION_CODENAME lines.
     while (<OSREL>) {
       $baseos = $1 if /^ID="?(\w+)"?/;
       $basever = $1 if /^VERSION_ID="?([\d.]+)"?/;
+      $basecodename =  $1 if ( /^VERSION_CODENAME="?(\w+)"?/ || /^UBUNTU_CODENAME="?(\w+)"?/ );
     }
     close OSREL;
 
-  } elsif (open LSBREL, '/etc/lsb-release') {
-    # Look for DISTRIB_ID and DISTRIB_RELEASE lines.
-    # We could also theoretically extract the dist codename, but since we have to hand-map
-    # it in so many other cases there's little point.
-    while (<LSBREL>) {
-      $baseos = $1 if /^DISTRIB_ID="?(\w+)"?/;
-      $basever = $1 if /^DISTRIB_RELEASE="?([\d.]+)"?/;
-    }
-    close LSBREL;
+  } elsif (open LSBREL, '-|', 'lsb_release', '-s', '-i', '-r', '-c') {
+    # Retrive dist name, version, and codename from lsb_release
+    chomp( $baseos = lc <LSBREL> );
+    chomp( $basever = <LSBREL> );
+    chomp( $basecodename = <LSBREL> );
+    close LSBREL
 
-  } elsif (-e $specglobals{__dpkg_query}) {
-# *eyeroll*  there *really* has to be a better way to go about this.  You
-# can't sanely build packages for multiple distro targets if you can't
-# programmatically figure out which one you're building on.
-
-# note that we care only about major release numbers; tracking minor or point
-# releases would be...  exponentially more painful.
-
-    # for the lazy copy-paster:  dpkg-query --showformat '${version}\n' -W base-files
-    # avoid shellisms
-    if (open BASEGETTER, '-|', $specglobals{__dpkg_query}, '--showformat', '${version}', '-W', 'base-files') {
-      $basever = <BASEGETTER>;
-      close BASEGETTER;
-
-      if ($basever =~ /ubuntu/) {
-        # Ubuntu, at least until they upset their versioning scheme again
-        # note that we remap the basefiles version to the public release number, to match the
-        # behaviour for Debian, and to match the unofficial standard for RHEL/Centos etc and Fedora
-        ($basever,$baseos) = $basever =~ /^([\d.]+)(ubuntu)\d/;
-      } else {
-        # Debian, or more "pure" derivative
-        $baseos = 'debian';
-        ($basever,my $majver) = $basever =~ /^((\d+)(?:\.\d)?)/;
-        $basever = $majver if $majver > 3;
-      }
-    }
-
-    if (not $basever) {
-      # Your llama is on fire
-      $basever = '99';
-      warn "Warning:  couldn't autodetect OS version, assuming sid/unstable\n";
-    }
-  } else { # got dpkg-query?
-    # call it woody, since sarge and newer have dpkg-query, and we don't much care about obsolete^n releases
-    $basever = '3.0';
-    $baseos = 'debian';
-  }
+  } else ( die "No 'os-release' file or 'lsb_release' program found. Sorry, I quit.\n"; ) }
 
   # rpmbuild expects either integers or strings, and some distros (*cough*Ubuntu*cough*)
   # have versions that get interpreted as strings, which creates comparison problems.
@@ -204,7 +127,7 @@ my %distmap = (
   (my $specbasever = $basever) =~ s/\.//;
 
   # Set some legacy globals.
-  $specglobals{debdist} = $distmap{$basever};
+  $specglobals{debdist} = $basecodename;
   $specglobals{debver} = $specbasever;
 
   # Set the standard generic OS-class globals;

--- a/debbuild
+++ b/debbuild
@@ -94,30 +94,126 @@ my %optflags = ( 'i386' => '-O2 -g -march=i386 -mcpu=i686',
 		'amd64'	=> '-O2 -g',
 		  'all'	=> '');
 
+# Hackery to try to bring some semblance of sanity to packages built for more
+# than one Debian version at the same time.  Whee.
+# /etc/debian-version and/or version of base-files package
+my %distmap = (
+# legacy Unbuntu
+	'3.1.9ubuntu'	=> 'dapper',
+	'6.06'		=> 'dapper',
+	'4ubuntu'	=> 'feisty',
+	'7.04'		=> 'feisty',
+        '4.0.1ubuntu'	=> 'hardy',
+	'8.04'		=> 'hardy',
+# Note we do NOT support identification of "subrelease" versions (ie semimajor updates
+# to a given release).  If your dependencies are really that tight, and you can't rely
+# on the versions of the actual dependencies, you're already in over your head, and
+# should probably only ship a tarballed installer.
+# only supporting LTS releases
+# base-files version doesn't map to the Ubuntu version the way Debian versions do, thus the doubled entries
+#	Ubuntu 12.04.5 LTS (Precise Pangolin)
+	'6.5ubuntu'	=> 'precise',
+	'12.04'		=> 'precise',
+#	Ubuntu 14.04.2 LTS (Trusty Tahr)
+	'7.2ubuntu'	=> 'trusty',
+	'14.04'		=> 'trusty',
+#	Ubuntu 16.04.0 LTS (Xenial Xerus)
+	'9.4ubuntu'	=> 'xenial',
+	'16.04'		=> 'xenial',
+# Debian releases
+	'3.0'	=> 'woody',
+	'3.1'	=> 'sarge',
+	'4'	=> 'etch',
+	'5'	=> 'lenny',
+	'6'	=> 'squeeze',
+	'7'	=> 'wheezy',
+	'8'	=> 'jessie',
+	'9'	=> 'stretch',
+	'99'	=> 'sid');
 
-{ # Analyze LSB information
-  my %lsb;
+# Enh.  There doesn't seem to be any better way to do this...  :(
+{
+# could theoretically also do something with this...  it's about as stable as "dpkg-query ..." below...  :(
+#  chomp( my $releasever = qx ( $specglobals{__cat} /etc/debian_version ) );
+  my $basever;
+  my $baseos;
 
-  if (open LSBINFO, '-|', 'lsb_release', '-s', '-i', '-r', '-c') {
-    chomp( $lsb{distributor} = lc <LSBINFO> );
-    chomp( $lsb{release} = <LSBINFO> );
-    chomp( $lsb{codename} = <LSBINFO> );
-    close LSBINFO;
-  } else { die "No 'lsb_release' found. Sorry, I quit.\n"; }
+  # Funny thing how files like this have become useful...
+  # Check for /etc/os-release.  If that doesn't exist, try /etc/lsb-release.  If that doesn't exist,
+  # check for existence of dpkg-query, and either call it Debian Woody (if missing), or fall through
+  # to guessing based on the version of the base-files package.
+  if (open OSREL, '/etc/os-release') {
+    # Look for ID and VERSION_ID lines.
+    while (<OSREL>) {
+      $baseos = $1 if /^ID="?(\w+)"?/;
+      $basever = $1 if /^VERSION_ID="?([\d.]+)"?/;
+    }
+    close OSREL;
+
+  } elsif (open LSBREL, '/etc/lsb-release') {
+    # Look for DISTRIB_ID and DISTRIB_RELEASE lines.
+    # We could also theoretically extract the dist codename, but since we have to hand-map
+    # it in so many other cases there's little point.
+    while (<LSBREL>) {
+      $baseos = $1 if /^DISTRIB_ID="?(\w+)"?/;
+      $basever = $1 if /^DISTRIB_RELEASE="?([\d.]+)"?/;
+    }
+    close LSBREL;
+
+  } elsif (-e $specglobals{__dpkg_query}) {
+# *eyeroll*  there *really* has to be a better way to go about this.  You
+# can't sanely build packages for multiple distro targets if you can't
+# programmatically figure out which one you're building on.
+
+# note that we care only about major release numbers; tracking minor or point
+# releases would be...  exponentially more painful.
+
+    # for the lazy copy-paster:  dpkg-query --showformat '${version}\n' -W base-files
+    # avoid shellisms
+    if (open BASEGETTER, '-|', $specglobals{__dpkg_query}, '--showformat', '${version}', '-W', 'base-files') {
+      $basever = <BASEGETTER>;
+      close BASEGETTER;
+
+      if ($basever =~ /ubuntu/) {
+        # Ubuntu, at least until they upset their versioning scheme again
+        # note that we remap the basefiles version to the public release number, to match the
+        # behaviour for Debian, and to match the unofficial standard for RHEL/Centos etc and Fedora
+        ($basever,$baseos) = $basever =~ /^([\d.]+)(ubuntu)\d/;
+      } else {
+        # Debian, or more "pure" derivative
+        $baseos = 'debian';
+        ($basever,my $majver) = $basever =~ /^((\d+)(?:\.\d)?)/;
+        $basever = $majver if $majver > 3;
+      }
+    }
+
+    if (not $basever) {
+      # Your llama is on fire
+      $basever = '99';
+      warn "Warning:  couldn't autodetect OS version, assuming sid/unstable\n";
+    }
+  } else { # got dpkg-query?
+    # call it woody, since sarge and newer have dpkg-query, and we don't much care about obsolete^n releases
+    $basever = '3.0';
+    $baseos = 'debian';
+  }
 
   # rpmbuild expects either integers or strings, and some distros (*cough*Ubuntu*cough*)
   # have versions that get interpreted as strings, which creates comparison problems.
   # This will make sure it's an integer to remain compatible.
-  (my $specbasever = $lsb{release}) =~ s/\.//;
+  (my $specbasever = $basever) =~ s/\.//;
 
   # Set some legacy globals.
-  $specglobals{debdist} = $lsb{codename};
+  $specglobals{debdist} = $distmap{$basever};
   $specglobals{debver} = $specbasever;
-  $specglobals{$lsb{distributor}} = $specbasever;
+
+  # Set the standard generic OS-class globals;
+  $baseos = lc $baseos;
+  $specglobals{$baseos} = $specbasever;
 
   # Default %{dist} to something marginally sane.  Note this should be overrideable by --define.
   # This has been chosen to most closely follow the usage in RHEL/CentOS and Fedora, ie "el5" or "fc20".
-  $specglobals{dist} = $lsb{distributor}.$lsb{release};
+  $specglobals{dist} = $baseos.$basever;
 
 } # done trying to set debian dist/version
 


### PR DESCRIPTION
This pull request addresses #44 and #45 by utilizing `lsb_release` in the event that `/etc/os-release` is unavailable.

The logic is simplified as it now has a hard dependency on *either* the presence of `/etc/os-release` or `lsb_release` programs. This will satisfy nearly all Linux distributions in use today.

For this code to work, distributions that don't provide `/etc/os-release` need `/usr/bin/lsb_release` installed instead.

WARNING: I have not tested this code. I'm not great with Perl, so a review to ensure it actually works as intended would be appreciated.

One case I'm not sure how to handle is getting Debian's codename out of `/etc/os-release`. They don't specify a `DEBIAN_CODENAME` value, but instead stick it in `VERSION`.

For example, Debian 8 defines `VERSION` as `"8 (jessie)"`. Obviously, I want the word in parenthesis. 