### PR TITLE
A couple of small fixes

### DIFF
--- a/debbuild
+++ b/debbuild
@@ -1861,24 +1861,6 @@ You could symlink F<~/.rpmmacros> to F<~/.debmacros> (or vice versa) and save yo
 
 B<debbuild> deliberately does a few things differently from B<rpmbuild>.
 
-=head2 BuildArch or BuildArchitecture
-
-B<rpmbuild> takes the last BuildArch entry it finds in the .spec file, whatever it is, and runs with that for all packages.  Debian’s repository system is fairly heavily designed around the assumption that a single source package may generate small binary (executable) packages for each arch, and large binary arch-all packages containing shared data.
-
-B<debbuild> allows this by using the architecture specified by (in order of preference):
-
-=over 4
-
-=item * Host architecture
-
-=item * BuildArch specified in .spec file preamble
-
-=item * “Last specified” BuildArch for packages with several subpackages
-
-=item * BuildArch specified in the %package section for that subpackage
-
-=back
-
 =head2 Finding out what packages should be built (--showpkgs)
 
 B<rpmbuild> does not include any convenient method I know of to list the packages a spec file will produce.  Since I needed this ability for another tool, I added it.

--- a/debbuild.spec
+++ b/debbuild.spec
@@ -27,6 +27,7 @@ Requires: perl, fakeroot
 Recommends: bzip2, gzip, xz-utils, unzip, zip
 Recommends: git, patch, pax, quilt
 Suggests: rpm, subversion
+Requires: lsb-release
 %endif
 BuildRoot: %{_tmppath}/%{name}-%{version}-%{release}-root
 BuildArch: noarch
@@ -71,6 +72,9 @@ rebuild .src.rpm source packages as .deb binary packages.
 %include %{S:101}
 
 %changelog
+* Fri Oct 28 2016  Neal Gompa <ngompa13@gmail.com>
+- Add lsb-release as requirement
+
 * Sat Dec 12 2015  Andreas Scherer <https://ascherer.github.io/>
 - Centrally control and distribute the 'version' number
 


### PR DESCRIPTION
This PR contains a couple of small fixes:

* The addition of `lsb-release` as a runtime dependency. This is necessary for old Debian/Ubuntu systems to work correctly with `debbuild`.

* The removal of the note about different behaviors of `BuildArch` between RPM and debbuild. RPM has had the same behavior since RPM 4.6.0.