### PR TITLE
Revert "Use 'install' in Makefile."

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,8 @@ all:
 	# nothing to do
 
 install:
-	install debbuild -D -t $(DESTDIR)/usr/bin
+	mkdir -p $(DESTDIR)/usr/bin
+	cp debbuild $(DESTDIR)/usr/bin
 
 	mkdir -p $(DESTDIR)$(MANDIR)/man8
 	pod2man --utf8 --center="DeepNet Dev Tools" --section 8 \


### PR DESCRIPTION
This change broke installing debbuild for Debian 7 and Ubuntu 12.04.

This reverts commit 84ba90d7b0891a69d230b82da67be5a70b6e292e.