### PR TITLE
Ensure identified library deps match to packages with '.' in names

### DIFF
--- a/debbuild
+++ b/debbuild
@@ -1636,7 +1636,7 @@ sub getreqs {
 # we have this lib?" deps.  >:(
 
   return unless $reqliblist; # possibly empty
-  return map { m/^([\w+-]+?):/ } qx($specglobals{__dpkg_query} -S$reqliblist);
+  return map { m/^([\w+-.]+?):/ } qx($specglobals{__dpkg_query} -S$reqliblist);
 
 } # end getreqs()
 


### PR DESCRIPTION
`dpkg` allows for package names to have `.` in it (such as `libglib2.0-0`). However, the regular expression set for this would fail on these packages and ignore them. Thus, this regular expression needs to be updated to match on this.