### PR TITLE
Correctly abort stage scripts and the build when errors occur

### DIFF
--- a/debbuild
+++ b/debbuild
@@ -1152,13 +1152,14 @@ sub execute_script {
   $build_template =~ s/set -x/set +x/ unless $verbosity;
   print SCRIPT $build_template;
   print SCRIPT expandmacros($script{$stage});
+  print SCRIPT expandmacros('%{___build_post}');
   close SCRIPT;
 
   # execute
-  print 'Calling '.($what or "%$stage")." script $scriptfile".
-    ($for or '')."...\n" if $verbosity;
-  system($scriptfile . ($verbosity > 1 ? '' : ' >/dev/null 2>&1'))
-    and die "Can't exec: $!\n";
+  print "Executing(".($what or "%$stage")."): " . expandmacros('%{___build_cmd}') ." ". $scriptfile.
+    ($for or '')."\n" if $verbosity;
+  system(expandmacros('%{___build_cmd}') .' '. $scriptfile . ($verbosity > 1 ? '' : ' >/dev/null 2>&1'))
+    and die "Exec of $scriptfile failed (%$stage): $?\n";
 
   # and clean up
   unlink $scriptfile;

--- a/macros/macros.in
+++ b/macros/macros.in
@@ -220,7 +220,7 @@ package or when debugging this package.\
 
 
 #%___build_body		%{nil}
-%___build_post		exit 0
+%___build_post		exit $?
 
 %___build_template	#!%{___build_shell}\
 %{___build_pre}\


### PR DESCRIPTION
In the event that a stage script (that is, the scripts for `%prep`, `%build`, `%install`, `%check`, or `%clean`) ends with a command that exits with a non-zero error code, the script should fail and the build should fail. Prior to this change, debbuild did not do this, which allowed for package builds to complete successfully despite failures that occurred throughout each stage of the package build.

This change now mimics how `rpmbuild(8)` calls stage scripts so that package build failures occur in a similar manner.