### PR TITLE
macros: Set %_localstatedir and %_sharedstatedir correctly

### DIFF
--- a/macros/macros.in
+++ b/macros/macros.in
@@ -242,8 +242,8 @@
 %_datadir		%{_prefix}/share
 %_docdir		%{_datadir}/doc
 %_sysconfdir		/etc
-%_sharedstatedir	%{_prefix}/com
-%_localstatedir		%{_prefix}/var
+%_sharedstatedir	%{_var}/lib
+%_localstatedir		%{_var}
 %_lib			lib
 %_libdir		%{_exec_prefix}/%{_lib}
 %_includedir		%{_prefix}/include


### PR DESCRIPTION
On virtually all Linux distributions (including Debian and RPM based ones), `%_localstatedir` is set to `/var` and `%_sharedstatedir` is set to `/var/lib`.

In RPM, these are set in `platform.in` based on what is passed into the `configure` script at build time, but debbuild doesn't work that way.

So, we set it correctly in the macros file so that everyone will Do the Right Thing(TM).