### PR TITLE
Add --nodeps support to debbuild

### DIFF
--- a/debbuild
+++ b/debbuild
@@ -169,7 +169,7 @@ if ($cmdopts{type} eq 'b') {
   # this also generates most of the shell script required.
   parse_spec($specglobals{specfile});
   die _('Can\'t build ').$pkgdata{main}{name}.
-      _(":  build requirements not met.\n") unless checkbuildreq();
+      _(":  build requirements not met.\n") unless ($cmdopts{nodeps} || checkbuildreq());
   exit 0 if $cmdopts{nobuild};
 
   # Expand macros as necessary.
@@ -315,6 +315,7 @@ sub parse_cmd {
     'showrc'        => \&dump_macros,
     'debug'         => \$cmdopts{debug},
     'sign'          => \$cmdopts{sign},
+    'nodeps'        => \$cmdopts{nodeps},
     'noprep'        => \$cmdopts{noprep},
     'nobuild'       => \$cmdopts{nobuild},
     'nocheck'       => \$cmdopts{nocheck},


### PR DESCRIPTION
This allows debbuild to be used on non-Debian-based systems to build Debian packages with the caveat that all dependencies must be fully specified (since the dependency generator will obviously not work).

This is useful for supporting foreign environments for package builds, as well as doing cross-target package builds, given the right environment settings.